### PR TITLE
 Feature: Add Dependency Injection setup for Lucene.NET providers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,5 +8,6 @@
 
     <PropertyGroup Label="NuGet Package Reference Versions">
         <LuceneNetVersion>4.8.0-beta00017</LuceneNetVersion>
+        <MicrosoftExtensionsVersion>9.0.6</MicrosoftExtensionsVersion>
     </PropertyGroup>
 </Project>

--- a/src/Lucene.Net.Extensions.DependencyInjection/ILuceneBuilder.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/ILuceneBuilder.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Lucene.Net.Extensions.DependencyInjection
+{
+    public interface ILuceneBuilder
+    {
+        ILuceneBuilder AddIndex(string name, Action<LuceneIndexOptions> configure);
+    }
+}

--- a/src/Lucene.Net.Extensions.DependencyInjection/Lucene.Net.Extensions.DependencyInjection.csproj
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Lucene.Net.Extensions.DependencyInjection.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    
+
     <ItemGroup>
         <PackageReference Include="Lucene.Net" Version="$(LuceneNetVersion)" />
+        <PackageReference Include="Lucene.Net.Analysis.Common" Version="$(LuceneNetVersion)" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsVersion)" />
     </ItemGroup>
 
 </Project>

--- a/src/Lucene.Net.Extensions.DependencyInjection/LuceneBuilder.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/LuceneBuilder.cs
@@ -1,0 +1,109 @@
+using Lucene.Net.Analysis;
+using Lucene.Net.Extensions.DependencyInjection.Registrations;
+using Lucene.Net.Index;
+using Lucene.Net.Search;
+using Lucene.Net.Store;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+
+namespace Lucene.Net.Extensions.DependencyInjection
+{
+    public class LuceneBuilder : ILuceneBuilder
+    {
+        private readonly IServiceCollection _services;
+
+        public LuceneBuilder(IServiceCollection services)
+        {
+            _services = services;
+        }
+
+        public ILuceneBuilder AddIndex(string name, Action<LuceneIndexOptions> configure)
+        {
+            var options = new LuceneIndexOptions();
+            configure(options);
+
+            var existingConfig = options.ConfigureIndexWriterConfig;
+
+            options.ConfigureIndexWriterConfig = (sp, config) =>
+            {
+                existingConfig?.Invoke(sp, config);
+
+                if (config.MaxBufferedDocs <= 0)
+                {
+                    config.MaxBufferedDocs = 1000;
+                }
+            };
+
+
+            _services.Configure<LuceneIndexOptions>(name, configure); // still preserve this for later use
+
+            // Register IndexReader
+            if (options.ReaderLifetime == ServiceLifetime.Singleton)
+                _services.AddKeyedSingleton<DirectoryReader>(name, CreateIndexReader);
+            else if (options.ReaderLifetime == ServiceLifetime.Scoped)
+                _services.AddKeyedScoped<DirectoryReader>(name, CreateIndexReader);
+            else
+                _services.AddKeyedTransient<DirectoryReader>(name, CreateIndexReader);
+
+            // Register IndexWriter
+            if (options.WriterLifetime == ServiceLifetime.Singleton)
+                _services.AddKeyedSingleton<IndexWriter>(name, CreateIndexWriter);
+            else if (options.WriterLifetime == ServiceLifetime.Scoped)
+                _services.AddKeyedScoped<IndexWriter>(name, CreateIndexWriter);
+            else
+                _services.AddKeyedTransient<IndexWriter>(name, CreateIndexWriter);
+
+            // Register IndexSearcher
+            if (options.SearcherLifetime == ServiceLifetime.Singleton)
+                _services.AddKeyedSingleton<IndexSearcher>(name, CreateIndexSearcher);
+            else if (options.SearcherLifetime == ServiceLifetime.Scoped)
+                _services.AddKeyedScoped<IndexSearcher>(name, CreateIndexSearcher);
+            else
+                _services.AddKeyedTransient<IndexSearcher>(name, CreateIndexSearcher);
+
+            // Register Registrations
+            _services.AddKeyedSingleton<IndexReaderRegistration>(name, (sp, _) => new IndexReaderRegistration(name, options, sp));
+            _services.AddKeyedSingleton<IndexWriterRegistration>(name, (sp, _) => new IndexWriterRegistration(name, options, sp));
+            _services.AddKeyedSingleton<IndexSearcherRegistration>(name, (sp, _) => new IndexSearcherRegistration(name, options));
+            _services.AddKeyedSingleton<Analyzer>(name, (sp, _) => options.EffectiveAnalyzer);
+
+            return this;
+        }
+
+        private static DirectoryReader CreateIndexReader(IServiceProvider sp, object? key)
+        {
+            var name = (string)key!;
+            var config = sp.GetRequiredService<IOptionsMonitor<LuceneIndexOptions>>().Get(name);
+            var directory = config.DirectoryFactory?.Invoke(sp) ?? FSDirectory.Open(config.IndexPath!);
+            return DirectoryReader.Open(directory);
+        }
+
+        private static IndexWriter CreateIndexWriter(IServiceProvider sp, object? key)
+        {
+            var name = (string)key!;
+            var config = sp.GetRequiredService<IOptionsMonitor<LuceneIndexOptions>>().Get(name);
+
+            var directory = config.DirectoryFactory?.Invoke(sp) ?? FSDirectory.Open(config.IndexPath!);
+
+            var writerConfig = new IndexWriterConfig(config.LuceneVersion, config.EffectiveAnalyzer)
+            {
+                IndexDeletionPolicy = config.EffectiveDeletionPolicy
+            };
+
+            config.ApplyWriterSettings(sp, writerConfig);
+
+            return new IndexWriter(directory, writerConfig);
+        }
+
+
+        private static IndexSearcher CreateIndexSearcher(IServiceProvider sp, object? key)
+        {
+            var name = (string)key!;
+            var readerRegistration = sp.GetRequiredKeyedService<IndexReaderRegistration>(name);
+
+            return new IndexSearcher(readerRegistration.GetReader(sp));
+        }
+
+    }
+}

--- a/src/Lucene.Net.Extensions.DependencyInjection/LuceneDIExtensions.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/LuceneDIExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using Lucene.Net.Extensions.DependencyInjection.Providers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Lucene.Net.Extensions.DependencyInjection
+{
+    public static class LuceneDIExtensions
+    {
+        public static ILuceneBuilder AddLucene(this IServiceCollection services)
+        {
+            services.AddTransient<IIndexReaderProvider, IndexReaderProvider>();
+            services.AddTransient<IIndexWriterProvider, IndexWriterProvider>();
+            services.AddTransient<IIndexSearcherProvider, IndexSearcherProvider>();
+            services.AddSingleton<IAnalyzerProvider, AnalyzerProvider>();
+
+            return new LuceneBuilder(services);
+        }
+
+    }
+}

--- a/src/Lucene.Net.Extensions.DependencyInjection/LuceneDIExtensions.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/LuceneDIExtensions.cs
@@ -15,6 +15,5 @@ namespace Lucene.Net.Extensions.DependencyInjection
 
             return new LuceneBuilder(services);
         }
-
     }
 }

--- a/src/Lucene.Net.Extensions.DependencyInjection/LuceneIndexOptions.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/LuceneIndexOptions.cs
@@ -1,0 +1,42 @@
+using System;
+using Lucene.Net.Analysis;
+using Lucene.Net.Analysis.Standard;
+using Lucene.Net.Index;
+using Lucene.Net.Util;
+using Microsoft.Extensions.DependencyInjection;
+using LuceneDirectory = Lucene.Net.Store.Directory;
+
+namespace Lucene.Net.Extensions.DependencyInjection
+{
+    public class LuceneIndexOptions
+    {
+        public string? IndexPath { get; set; }
+        public Func<IServiceProvider, LuceneDirectory>? DirectoryFactory { get; set; }
+
+        public Analyzer? Analyzer { get; set; }
+        public LuceneVersion LuceneVersion { get; set; } = LuceneVersion.LUCENE_48;
+
+        public bool EnableRefreshing { get; set; } = false;
+
+        public IndexDeletionPolicy? DeletionPolicy { get; set; }
+
+        public Action<IServiceProvider, IndexWriterConfig>? ConfigureIndexWriterConfig { get; set; }
+
+        public ServiceLifetime ReaderLifetime { get; set; } = ServiceLifetime.Singleton;
+        public ServiceLifetime WriterLifetime { get; set; } = ServiceLifetime.Singleton;
+        public ServiceLifetime SearcherLifetime { get; set; } = ServiceLifetime.Singleton;
+
+        // Effective fallbacks
+        public Analyzer EffectiveAnalyzer => Analyzer ?? new StandardAnalyzer(LuceneVersion);
+        public IndexDeletionPolicy EffectiveDeletionPolicy =>
+            DeletionPolicy ?? new SnapshotDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy());
+
+        // ✅ Helper method
+        public void ApplyWriterSettings(IServiceProvider sp, IndexWriterConfig config)
+        {
+            ConfigureIndexWriterConfig?.Invoke(sp, config);
+        }
+
+
+    }
+}

--- a/src/Lucene.Net.Extensions.DependencyInjection/LuceneIndexOptions.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/LuceneIndexOptions.cs
@@ -23,7 +23,7 @@ namespace Lucene.Net.Extensions.DependencyInjection
         public Action<IServiceProvider, IndexWriterConfig>? ConfigureIndexWriterConfig { get; set; }
 
         public ServiceLifetime ReaderLifetime { get; set; } = ServiceLifetime.Singleton;
-        public ServiceLifetime WriterLifetime { get; set; } = ServiceLifetime.Singleton;
+        public ServiceLifetime? WriterLifetime { get; set; }
         public ServiceLifetime SearcherLifetime { get; set; } = ServiceLifetime.Singleton;
 
         // Effective fallbacks
@@ -36,7 +36,5 @@ namespace Lucene.Net.Extensions.DependencyInjection
         {
             ConfigureIndexWriterConfig?.Invoke(sp, config);
         }
-
-
     }
 }

--- a/src/Lucene.Net.Extensions.DependencyInjection/Providers/AnalyzerProvider.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Providers/AnalyzerProvider.cs
@@ -1,0 +1,20 @@
+using Lucene.Net.Analysis;
+using Microsoft.Extensions.DependencyInjection;
+
+
+namespace Lucene.Net.Extensions.DependencyInjection.Providers
+{
+    public class AnalyzerProvider : IAnalyzerProvider
+    {
+        private readonly IServiceProvider _serviceProvider;
+        public AnalyzerProvider(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public Analyzer Get(string name)
+        {
+            return _serviceProvider.GetRequiredKeyedService<Analyzer>(name);
+        }
+    }
+}

--- a/src/Lucene.Net.Extensions.DependencyInjection/Providers/IAnalyzerProvider.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Providers/IAnalyzerProvider.cs
@@ -1,0 +1,9 @@
+using Lucene.Net.Analysis;
+
+namespace Lucene.Net.Extensions.DependencyInjection.Providers
+{
+    public interface IAnalyzerProvider
+    {
+        Analyzer Get(string name);
+    }
+}

--- a/src/Lucene.Net.Extensions.DependencyInjection/Providers/IIndexReaderProvider.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Providers/IIndexReaderProvider.cs
@@ -1,0 +1,10 @@
+using Lucene.Net.Index;
+
+namespace Lucene.Net.Extensions.DependencyInjection.Providers
+{
+    public interface IIndexReaderProvider
+    {
+        IndexReader Get(string name);
+    }
+
+}

--- a/src/Lucene.Net.Extensions.DependencyInjection/Providers/IIndexReaderProvider.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Providers/IIndexReaderProvider.cs
@@ -6,5 +6,4 @@ namespace Lucene.Net.Extensions.DependencyInjection.Providers
     {
         IndexReader Get(string name);
     }
-
 }

--- a/src/Lucene.Net.Extensions.DependencyInjection/Providers/IIndexSearcherProvider.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Providers/IIndexSearcherProvider.cs
@@ -1,0 +1,9 @@
+using Lucene.Net.Search;
+
+namespace Lucene.Net.Extensions.DependencyInjection.Providers
+{
+    public interface IIndexSearcherProvider
+    {
+        IndexSearcher Get(string name);
+    }
+}

--- a/src/Lucene.Net.Extensions.DependencyInjection/Providers/IIndexWriterProvider.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Providers/IIndexWriterProvider.cs
@@ -1,0 +1,9 @@
+using Lucene.Net.Index;
+
+namespace Lucene.Net.Extensions.DependencyInjection.Providers
+{
+    public interface IIndexWriterProvider
+    {
+        IndexWriter Get(string name);
+    }
+}

--- a/src/Lucene.Net.Extensions.DependencyInjection/Providers/IndexReaderProvider.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Providers/IndexReaderProvider.cs
@@ -1,0 +1,22 @@
+using Lucene.Net.Index;
+using Lucene.Net.Extensions.DependencyInjection.Registrations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Lucene.Net.Extensions.DependencyInjection.Providers
+{
+    public class IndexReaderProvider : IIndexReaderProvider
+    {
+        private readonly IServiceProvider _sp;
+
+        public IndexReaderProvider(IServiceProvider sp)
+        {
+            _sp = sp;
+        }
+
+        public IndexReader Get(string name)
+        {
+            var registration = _sp.GetRequiredKeyedService<IndexReaderRegistration>(name);
+            return registration.GetReader(_sp);
+        }
+    }
+}

--- a/src/Lucene.Net.Extensions.DependencyInjection/Providers/IndexSearcherProvider.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Providers/IndexSearcherProvider.cs
@@ -1,0 +1,22 @@
+using Lucene.Net.Search;
+using Lucene.Net.Extensions.DependencyInjection.Registrations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Lucene.Net.Extensions.DependencyInjection.Providers
+{
+    public class IndexSearcherProvider : IIndexSearcherProvider
+    {
+        private readonly IServiceProvider _sp;
+
+        public IndexSearcherProvider(IServiceProvider sp)
+        {
+            _sp = sp;
+        }
+
+        public IndexSearcher Get(string name)
+        {
+            var registration = _sp.GetRequiredKeyedService<IndexSearcherRegistration>(name);
+            return registration.GetSearcher(_sp);
+        }
+    }
+}

--- a/src/Lucene.Net.Extensions.DependencyInjection/Providers/IndexWriterProvider.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Providers/IndexWriterProvider.cs
@@ -1,0 +1,22 @@
+using Lucene.Net.Index;
+using Lucene.Net.Extensions.DependencyInjection.Registrations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Lucene.Net.Extensions.DependencyInjection.Providers
+{
+    public class IndexWriterProvider : IIndexWriterProvider
+    {
+        private readonly IServiceProvider _sp;
+
+        public IndexWriterProvider(IServiceProvider sp)
+        {
+            _sp = sp;
+        }
+
+        public IndexWriter Get(string name)
+        {
+            var registration = _sp.GetRequiredKeyedService<IndexWriterRegistration>(name);
+            return registration.GetWriter(_sp);
+        }
+    }
+}

--- a/src/Lucene.Net.Extensions.DependencyInjection/Providers/IndexWriterProvider.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Providers/IndexWriterProvider.cs
@@ -15,7 +15,7 @@ namespace Lucene.Net.Extensions.DependencyInjection.Providers
 
         public IndexWriter Get(string name)
         {
-            var registration = _sp.GetRequiredKeyedService<IndexWriterRegistration>(name);
+            var registration = _sp.GetKeyedService<IndexWriterRegistration>(name);
             // Explicit null-check to give a personal clearer error about Writer instead of DI resolution failure.
             if (registration == null)
                 throw new InvalidOperationException(

--- a/src/Lucene.Net.Extensions.DependencyInjection/Providers/IndexWriterProvider.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Providers/IndexWriterProvider.cs
@@ -16,6 +16,12 @@ namespace Lucene.Net.Extensions.DependencyInjection.Providers
         public IndexWriter Get(string name)
         {
             var registration = _sp.GetRequiredKeyedService<IndexWriterRegistration>(name);
+            // Explicit null-check to give a personal clearer error about Writer instead of DI resolution failure.
+            if (registration == null)
+                throw new InvalidOperationException(
+            $"No writer is registered for index '{name}'. " +
+            $"Did you forget to configure WriterLifetime?");
+
             return registration.GetWriter(_sp);
         }
     }

--- a/src/Lucene.Net.Extensions.DependencyInjection/Registrations/IndexReaderRegistration.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Registrations/IndexReaderRegistration.cs
@@ -1,0 +1,78 @@
+using System;
+using Lucene.Net.Index;
+using Lucene.Net.Store;
+using Microsoft.Extensions.DependencyInjection;
+using LuceneDirectory = Lucene.Net.Store.Directory;
+
+namespace Lucene.Net.Extensions.DependencyInjection.Registrations
+{
+    public class IndexReaderRegistration : IDisposable
+    {
+        private readonly string _name;
+        private readonly LuceneDirectory _directory;
+        private readonly ServiceLifetime _lifetime;
+        private readonly bool _enableRefreshing;
+        private DirectoryReader? _cachedReader;
+        private readonly object _lock = new();
+        private bool _disposed;
+
+        public IndexReaderRegistration(string name, LuceneIndexOptions config, IServiceProvider rootSp)
+        {
+            _name = name;
+            _lifetime = config.ReaderLifetime;
+            _enableRefreshing = config.EnableRefreshing;
+            _directory = config.DirectoryFactory?.Invoke(rootSp) ?? FSDirectory.Open(config.IndexPath!);
+        }
+
+        public DirectoryReader GetReader(IServiceProvider sp)
+        {
+            return _lifetime switch
+            {
+                ServiceLifetime.Singleton => _enableRefreshing
+                    ? GetSingletonReader()
+                    : sp.GetRequiredKeyedService<DirectoryReader>(_name),
+
+                ServiceLifetime.Scoped or ServiceLifetime.Transient =>
+                    sp.GetRequiredKeyedService<DirectoryReader>(_name),
+
+                _ => throw new NotSupportedException($"Unsupported lifetime: {_lifetime}")
+            };
+        }
+
+        private DirectoryReader GetSingletonReader()
+        {
+            lock (_lock)
+            {
+                if (_cachedReader == null)
+                {
+                    _cachedReader = DirectoryReader.Open(_directory);
+                }
+                else
+                {
+                    var maybeUpdated = DirectoryReader.OpenIfChanged(_cachedReader);
+                    if (maybeUpdated != null)
+                    {
+                        _cachedReader.Dispose();
+                        _cachedReader = maybeUpdated;
+                    }
+                }
+
+                return _cachedReader;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+
+            lock (_lock)
+            {
+                _cachedReader?.Dispose();
+                _cachedReader = null;
+            }
+
+            _disposed = true;
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Lucene.Net.Extensions.DependencyInjection/Registrations/IndexSearcherRegistration.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Registrations/IndexSearcherRegistration.cs
@@ -1,0 +1,65 @@
+using System;
+using Lucene.Net.Index;
+using Lucene.Net.Search;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Lucene.Net.Extensions.DependencyInjection.Registrations
+{
+    public class IndexSearcherRegistration : IDisposable
+    {
+        private readonly string _name;
+        private readonly ServiceLifetime _lifetime;
+        private IndexSearcher? _cachedSearcher;
+        private readonly object _lock = new();
+        private bool _disposed;
+
+        public IndexSearcherRegistration(string name, LuceneIndexOptions config)
+        {
+            _name = name;
+            _lifetime = config.SearcherLifetime;
+        }
+
+        public IndexSearcher GetSearcher(IServiceProvider sp)
+        {
+            return _lifetime switch
+            {
+                ServiceLifetime.Singleton => GetSingletonSearcher(sp),
+                ServiceLifetime.Scoped or ServiceLifetime.Transient => sp.GetRequiredKeyedService<IndexSearcher>(_name),
+                _ => throw new NotSupportedException($"Unsupported lifetime: {_lifetime}")
+            };
+        }
+
+        private IndexSearcher GetSingletonSearcher(IServiceProvider sp)
+        {
+            lock (_lock)
+            {
+                var readerReg = sp.GetRequiredKeyedService<IndexReaderRegistration>(_name);
+                var currentReader = readerReg.GetReader(sp);
+
+                if (_cachedSearcher?.IndexReader != currentReader)
+                {
+                    if (_cachedSearcher?.IndexReader is IDisposable disposableReader)
+                        disposableReader.Dispose();
+
+                    _cachedSearcher = new IndexSearcher(currentReader);
+                }
+
+                return _cachedSearcher;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+
+            lock (_lock)
+            {
+                _cachedSearcher?.IndexReader?.Dispose();
+                _cachedSearcher = null;
+            }
+
+            _disposed = true;
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Lucene.Net.Extensions.DependencyInjection/Registrations/IndexSearcherRegistration.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Registrations/IndexSearcherRegistration.cs
@@ -38,9 +38,6 @@ namespace Lucene.Net.Extensions.DependencyInjection.Registrations
 
                 if (_cachedSearcher?.IndexReader != currentReader)
                 {
-                    if (_cachedSearcher?.IndexReader is IDisposable disposableReader)
-                        disposableReader.Dispose();
-
                     _cachedSearcher = new IndexSearcher(currentReader);
                 }
 
@@ -54,7 +51,6 @@ namespace Lucene.Net.Extensions.DependencyInjection.Registrations
 
             lock (_lock)
             {
-                _cachedSearcher?.IndexReader?.Dispose();
                 _cachedSearcher = null;
             }
 

--- a/src/Lucene.Net.Extensions.DependencyInjection/Registrations/IndexWriterRegistration.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Registrations/IndexWriterRegistration.cs
@@ -1,0 +1,83 @@
+using System;
+using Lucene.Net.Index;
+using Lucene.Net.Store;
+using Microsoft.Extensions.DependencyInjection;
+using LuceneDirectory = Lucene.Net.Store.Directory;
+
+namespace Lucene.Net.Extensions.DependencyInjection.Registrations
+{
+    public class IndexWriterRegistration : IDisposable
+    {
+        private readonly string _name;
+        private readonly LuceneDirectory _directory;
+        private readonly IndexWriterConfig _writerConfig;
+        private readonly ServiceLifetime _lifetime;
+
+        private IndexWriter? _cachedWriter;
+        private readonly object _lock = new();
+        private bool _disposed;
+
+        public IndexWriterRegistration(string name, LuceneIndexOptions config, IServiceProvider rootSp)
+        {
+            _name = name;
+            _lifetime = config.WriterLifetime;
+
+            _directory = config.DirectoryFactory?.Invoke(rootSp)
+                         ?? FSDirectory.Open(config.IndexPath!);
+
+            _writerConfig = new IndexWriterConfig(config.LuceneVersion, config.EffectiveAnalyzer)
+            {
+                IndexDeletionPolicy = config.EffectiveDeletionPolicy
+            };
+
+            config.ApplyWriterSettings(rootSp, _writerConfig);
+        }
+
+        public IndexWriter GetWriter(IServiceProvider sp)
+        {
+            return _lifetime switch
+            {
+                ServiceLifetime.Singleton => GetSingletonWriter(),
+                ServiceLifetime.Scoped or ServiceLifetime.Transient =>
+                    sp.GetRequiredKeyedService<IndexWriter>(_name),
+                _ => throw new NotSupportedException($"Unsupported lifetime: {_lifetime}")
+            };
+        }
+
+        private IndexWriter GetSingletonWriter()
+        {
+            if (_cachedWriter != null) return _cachedWriter;
+
+            lock (_lock)
+            {
+                if (_cachedWriter == null)
+                {
+                    try
+                    {
+                        _cachedWriter = new IndexWriter(_directory, _writerConfig);
+                    }
+                    catch (LockObtainFailedException ex)
+                    {
+                        throw new InvalidOperationException(
+                            "IndexWriter lock failed. Is another process writing to the index?",
+                            ex
+                        );
+                    }
+                }
+            }
+
+            return _cachedWriter!;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+
+            _cachedWriter?.Dispose();
+            _cachedWriter = null;
+
+            _disposed = true;
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Lucene.Net.Extensions.DependencyInjection/Registrations/IndexWriterRegistration.cs
+++ b/src/Lucene.Net.Extensions.DependencyInjection/Registrations/IndexWriterRegistration.cs
@@ -20,7 +20,7 @@ namespace Lucene.Net.Extensions.DependencyInjection.Registrations
         public IndexWriterRegistration(string name, LuceneIndexOptions config, IServiceProvider rootSp)
         {
             _name = name;
-            _lifetime = config.WriterLifetime;
+            _lifetime = config.WriterLifetime!.Value; // Safe because service is only registered when WriterLifetime.HasValue is true
 
             _directory = config.DirectoryFactory?.Invoke(rootSp)
                          ?? FSDirectory.Open(config.IndexPath!);


### PR DESCRIPTION

**Description:**
This PR introduces the initial dependency injection (DI) setup for Lucene.NET, providing a structured way to register and resolve core Lucene components.

**Key additions:**

* **`ILuceneBuilder` / `LuceneBuilder`** – Fluent API for configuring Lucene services.
* **`LuceneDIExtensions`** – Extension methods for service registration.
* **`LuceneIndexOptions`** – Configuration model for index-related settings.
* **Providers**

  * `IAnalyzerProvider` / `AnalyzerProvider`
  * `IIndexReaderProvider` / `IndexReaderProvider`
  * `IIndexSearcherProvider` / `IndexSearcherProvider`
  * `IIndexWriterProvider` / `IndexWriterProvider`
* **Registrations**

  * `IndexReaderRegistration`
  * `IndexSearcherRegistration`
  * `IndexWriterRegistration`

**Folder structure:**

```
src/Lucene.Net.Extensions.DependencyInjection/
    LuceneDIExtensions.cs
    ILuceneBuilder.cs
    LuceneBuilder.cs
    LuceneIndexOptions.cs
    Providers/
        IAnalyzerProvider.cs
        AnalyzerProvider.cs
        IIndexReaderProvider.cs
        IndexReaderProvider.cs
        IIndexSearcherProvider.cs
        IndexSearcherProvider.cs
        IIndexWriterProvider.cs
        IndexWriterProvider.cs
    Registrations/
        IndexReaderRegistration.cs
        IndexSearcherRegistration.cs
        IndexWriterRegistration.cs
```

**Notes:**

* All providers are designed to resolve components using `IServiceProvider` with keyed service resolution.
* Structure is designed for future extensibility and modular registration of additional Lucene.NET services.
* This is the foundation for DI integration — no behavior changes to existing Lucene.NET logic.

---
