### PR TITLE
feat: Add Lucene Replication Server Extensions (ASP.NET Core + SelfHost)

### DIFF
--- a/src/Lucene.Net.Extensions.AspNetCore.Replicator/Adapters/AspNetCoreReplicationRequest.cs
+++ b/src/Lucene.Net.Extensions.AspNetCore.Replicator/Adapters/AspNetCoreReplicationRequest.cs
@@ -1,0 +1,41 @@
+using Lucene.Net.Replicator.Http.Abstractions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Lucene.Net.Extensions.AspNetCore.Replicator.Adapters;
+
+public class AspNetCoreReplicationRequest : IReplicationRequest
+{
+    private readonly HttpRequest _request;
+
+    public AspNetCoreReplicationRequest(HttpRequest request)
+    {
+        _request = request ?? throw new ArgumentNullException(nameof(request));
+    }
+
+    public Stream InputStream => _request.Body;
+
+    public string Method => _request.Method;
+
+    public string Path => _request.Path;
+
+    public string? QueryParam(string name)
+    {
+        if (_request.Query.TryGetValue(name, out var queryVal))
+            return queryVal.ToString();
+
+        var routeData = _request.HttpContext.GetRouteData();
+        if (routeData.Values.TryGetValue(name, out var routeVal))
+            return routeVal?.ToString();
+
+        return null;
+    }
+
+    public string? GetHeader(string name)
+    {
+        return _request.Headers[name].FirstOrDefault();
+    }
+}

--- a/src/Lucene.Net.Extensions.AspNetCore.Replicator/Adapters/AspNetCoreReplicationResponse.cs
+++ b/src/Lucene.Net.Extensions.AspNetCore.Replicator/Adapters/AspNetCoreReplicationResponse.cs
@@ -1,0 +1,64 @@
+using Lucene.Net.Replicator.Http.Abstractions;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Lucene.Net.Extensions.AspNetCore.Replicator.Adapters;
+
+public class AspNetCoreReplicationResponse : IReplicationResponse
+{
+    private readonly HttpResponse _response;
+
+    public AspNetCoreReplicationResponse(HttpResponse response)
+    {
+        _response = response ?? throw new ArgumentNullException(nameof(response));
+    }
+
+    public Stream OutputStream => _response.Body;
+
+    public Stream Body => _response.Body;
+
+    public int StatusCode
+    {
+        get => _response.StatusCode;
+        set => _response.StatusCode = value;
+    }
+
+    public void SetStatusCode(int code)
+    {
+        _response.StatusCode = code;
+    }
+
+    public void SetHeader(string name, string value)
+    {
+        if (!string.IsNullOrWhiteSpace(name) && value != null)
+        {
+            _response.Headers[name] = value;
+        }
+    }
+
+    public void Flush()
+    {
+        if (!_response.Body.CanWrite) return;
+
+        // ASP.NET Core may throw InvalidOperationException if sync IO is not allowed
+        try
+        {
+            _response.Body.FlushAsync().GetAwaiter().GetResult();
+        }
+        catch (InvalidOperationException)
+        {
+            // If async flush fails due to disallowed sync IO, attempt direct sync
+            _response.Body.Flush();
+        }
+    }
+
+    public async Task FlushAsync()
+    {
+        if (_response.Body.CanWrite)
+        {
+            await _response.Body.FlushAsync();
+        }
+    }
+}

--- a/src/Lucene.Net.Extensions.AspNetCore.Replicator/Lucene.Net.Extensions.AspNetCore.Replicator.csproj
+++ b/src/Lucene.Net.Extensions.AspNetCore.Replicator/Lucene.Net.Extensions.AspNetCore.Replicator.csproj
@@ -1,7 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <ItemGroup>
-      <ProjectReference Include="..\Lucene.Net.Extensions.DependencyInjection\Lucene.Net.Extensions.DependencyInjection.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference
+      Include="..\Lucene.Net.Extensions.DependencyInjection\Lucene.Net.Extensions.DependencyInjection.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Lucene.Net" Version="$(LuceneNetVersion)" />
+    <PackageReference Include="Lucene.Net.Analysis.Common" Version="$(LuceneNetVersion)" />
+    <PackageReference Include="Lucene.Net.Replicator" Version="$(LuceneNetVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Pulls in Microsoft.AspNetCore.Routing, Http, etc. from the shared framework -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
 </Project>

--- a/src/Lucene.Net.Extensions.AspNetCore.Replicator/LuceneReplicationEndpointExtensions.cs
+++ b/src/Lucene.Net.Extensions.AspNetCore.Replicator/LuceneReplicationEndpointExtensions.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Lucene.Net.Replicator;
+using Lucene.Net.Replicator.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Lucene.Net.Extensions.AspNetCore.Replicator.Adapters;
+
+namespace Lucene.Net.Extensions.AspNetCore.Replicator;
+
+public static class LuceneReplicationEndpointExtensions
+{
+    public static IEndpointRouteBuilder MapLuceneReplicationServer(
+        this IEndpointRouteBuilder endpoints,
+        string basePath,
+        IDictionary<string, IReplicator> shardMap)
+    {
+        var contextPath = NormalizeContextPath(basePath);
+
+        var replicationService = new ReplicationService(
+            new Dictionary<string, IReplicator>(shardMap, StringComparer.OrdinalIgnoreCase),
+            context: contextPath);
+
+        var pattern = $"{contextPath}/{{shard}}/{{action}}";
+
+        endpoints.Map(pattern, async context =>
+        {
+            try
+            {
+                var req = new AspNetCoreReplicationRequest(context.Request);
+                var res = new AspNetCoreReplicationResponse(context.Response);
+
+                replicationService.Perform(req, res);
+                await res.FlushAsync();
+            }
+            catch (Exception ex)
+            {
+                var logger = context.RequestServices.GetService<ILoggerFactory>()?.CreateLogger("LuceneReplication");
+                logger?.LogError(ex, "Replication request failed.");
+                context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                await context.Response.WriteAsync("Replication error.");
+            }
+        });
+
+        return endpoints;
+    }
+
+    private static string NormalizeContextPath(string basePath)
+    {
+        if (string.IsNullOrWhiteSpace(basePath))
+            throw new ArgumentException("Base path cannot be null or empty.", nameof(basePath));
+
+        return "/" + basePath.Trim().Trim('/');
+    }
+}

--- a/src/Lucene.Net.Extensions.SelfHost.Replicator/Adapters/AspNetCoreReplicationRequest.cs
+++ b/src/Lucene.Net.Extensions.SelfHost.Replicator/Adapters/AspNetCoreReplicationRequest.cs
@@ -1,0 +1,42 @@
+using Lucene.Net.Replicator.Http.Abstractions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Lucene.Net.Extensions.SelfHost.Replicator.Adapters;
+
+public class AspNetCoreReplicationRequest : IReplicationRequest
+{
+    private readonly HttpRequest _request;
+
+    public AspNetCoreReplicationRequest(HttpRequest request)
+    {
+        _request = request ?? throw new ArgumentNullException(nameof(request));
+    }
+
+    public Stream InputStream => _request.Body;
+
+    public string Method => _request.Method;
+
+    public string Path => _request.Path;
+
+    public string? QueryParam(string name)
+    {
+        if (_request.Query.TryGetValue(name, out var queryVal))
+            return queryVal.ToString();
+
+        var routeData = _request.HttpContext.GetRouteData();
+        if (routeData.Values.TryGetValue(name, out var routeVal))
+            return routeVal?.ToString();
+
+        return null;
+    }
+
+    public string? GetHeader(string name)
+    {
+        return _request.Headers[name].FirstOrDefault();
+    }
+}
+

--- a/src/Lucene.Net.Extensions.SelfHost.Replicator/Adapters/AspNetCoreReplicationResponse.cs
+++ b/src/Lucene.Net.Extensions.SelfHost.Replicator/Adapters/AspNetCoreReplicationResponse.cs
@@ -1,0 +1,65 @@
+using Lucene.Net.Replicator.Http.Abstractions;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Lucene.Net.Extensions.SelfHost.Replicator.Adapters;
+
+public class AspNetCoreReplicationResponse : IReplicationResponse
+{
+    private readonly HttpResponse _response;
+
+    public AspNetCoreReplicationResponse(HttpResponse response)
+    {
+        _response = response ?? throw new ArgumentNullException(nameof(response));
+    }
+
+    public Stream OutputStream => _response.Body;
+
+    public Stream Body => _response.Body;
+
+    public int StatusCode
+    {
+        get => _response.StatusCode;
+        set => _response.StatusCode = value;
+    }
+
+    public void SetStatusCode(int code)
+    {
+        _response.StatusCode = code;
+    }
+
+    public void SetHeader(string name, string value)
+    {
+        if (!string.IsNullOrWhiteSpace(name) && value != null)
+        {
+            _response.Headers[name] = value;
+        }
+    }
+
+    public void Flush()
+    {
+        if (!_response.Body.CanWrite) return;
+
+        // ASP.NET Core may throw InvalidOperationException if sync IO is not allowed
+        try
+        {
+            _response.Body.FlushAsync().GetAwaiter().GetResult();
+        }
+        catch (InvalidOperationException)
+        {
+            // If async flush fails due to disallowed sync IO, attempt direct sync
+            _response.Body.Flush();
+        }
+    }
+
+    public async Task FlushAsync()
+    {
+        if (_response.Body.CanWrite)
+        {
+            await _response.Body.FlushAsync();
+        }
+    }
+}
+

--- a/src/Lucene.Net.Extensions.SelfHost.Replicator/Lucene.Net.Extensions.SelfHost.Replicator.csproj
+++ b/src/Lucene.Net.Extensions.SelfHost.Replicator/Lucene.Net.Extensions.SelfHost.Replicator.csproj
@@ -1,7 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <ItemGroup>
-      <ProjectReference Include="..\Lucene.Net.Extensions.DependencyInjection\Lucene.Net.Extensions.DependencyInjection.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference
+      Include="..\Lucene.Net.Extensions.DependencyInjection\Lucene.Net.Extensions.DependencyInjection.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Lucene.Net" Version="$(LuceneNetVersion)" />
+    <PackageReference Include="Lucene.Net.Analysis.Common" Version="$(LuceneNetVersion)" />
+    <PackageReference Include="Lucene.Net.Replicator" Version="$(LuceneNetVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Pulls in  HttpContext, Routing, Builder, Kestrel, etc. from the shared framework -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
 </Project>

--- a/src/Lucene.Net.Extensions.SelfHost.Replicator/Options/ReplicationServerOptions.cs
+++ b/src/Lucene.Net.Extensions.SelfHost.Replicator/Options/ReplicationServerOptions.cs
@@ -1,0 +1,11 @@
+using Lucene.Net.Replicator;
+
+namespace Lucene.Net.Extensions.SelfHost.Replicator.Options;
+
+public class ReplicationServerOptions
+{
+    public int Port { get; set; } = 5000;
+    // User supplies ready-to-use replicators
+    public Dictionary<string, IReplicator> Replicators { get; set; }
+        = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Lucene.Net.Extensions.SelfHost.Replicator/ServiceCollectionExtensions.cs
+++ b/src/Lucene.Net.Extensions.SelfHost.Replicator/ServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Lucene.Net.Replicator;
+using Lucene.Net.Extensions.SelfHost.Replicator.Options;
+using Lucene.Net.Extensions.SelfHost.Replicator.Services;
+
+namespace Lucene.Net.Extensions.SelfHost.Replicator;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddLuceneReplicationServer(this IServiceCollection services, Action<ReplicationServerOptions> configureOptions)
+    {
+        services.Configure(configureOptions);
+        services.AddHostedService<ReplicationServerService>();
+
+        return services;
+    }
+}

--- a/src/Lucene.Net.Extensions.SelfHost.Replicator/Services/ReplicationServerService.cs
+++ b/src/Lucene.Net.Extensions.SelfHost.Replicator/Services/ReplicationServerService.cs
@@ -1,0 +1,77 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Lucene.Net.Replicator;
+using Lucene.Net.Replicator.Http;
+using Lucene.Net.Extensions.SelfHost.Replicator.Options;
+using Lucene.Net.Extensions.SelfHost.Replicator.Adapters;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Lucene.Net.Extensions.SelfHost.Replicator.Services;
+
+public class ReplicationServerService : BackgroundService
+{
+    private readonly ILogger<ReplicationServerService> _logger;
+    private readonly ReplicationServerOptions _options;
+    private ReplicationService? _service;
+
+    public ReplicationServerService(
+        ILogger<ReplicationServerService> logger,
+        IOptions<ReplicationServerOptions> options)
+    {
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation(
+            "Starting Lucene Replication Server on port {Port} with {ShardCount} shard(s)...",
+            _options.Port, _options.Replicators.Count);
+
+        // ✅ Build one ReplicationService for all shards
+        _service = new ReplicationService(_options.Replicators);
+
+        var app = SetupKestrelServer();
+        app.Urls.Add($"http://localhost:{_options.Port}");
+        await app.RunAsync(stoppingToken);
+    }
+
+    private WebApplication SetupKestrelServer()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.Configure<KestrelServerOptions>(o => o.AllowSynchronousIO = true);
+
+        var app = builder.Build();
+
+        app.Map("/replicate/{shard}/{action}", async (HttpContext context, string shard, string action) =>
+        {
+            if (!_options.Replicators.ContainsKey(shard))
+            {
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+                await context.Response.WriteAsync($"Unknown shard: {shard}");
+                return;
+            }
+
+            try
+            {
+                var req = new AspNetCoreReplicationRequest(context.Request);
+                var res = new AspNetCoreReplicationResponse(context.Response);
+
+                // ✅ Reuse the single ReplicationService instance
+                _service!.Perform(req, res);
+                await res.FlushAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error handling replication request for shard {Shard}", shard);
+                context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            }
+        });
+
+        return app;
+    }
+}


### PR DESCRIPTION

---
**Description**
This PR introduces **two new extension libraries** to make hosting a Lucene.Net replication server simple and flexible:

1. **`Lucene.Net.Extensions.AspNetCore.Replicator`**

   * Designed for **ASP.NET Core applications**.
   * Provides a middleware extension to expose replication endpoints inside an existing ASP.NET Core app.

2. **`Lucene.Net.Extensions.SelfHost.Replicator`**

   * Designed for **non-ASP.NET Core applications** (console apps, worker services).
   * Provides a `BackgroundService` that hosts a standalone HTTP replication server using Kestrel.

Together, these allow developers to easily plug Lucene.Net’s replication mechanism into their infrastructure with minimal setup.

---

### ✨ Key Features

#### ASP.NET Core Replicator

* `MapLuceneReplicationServer` extension for `IEndpointRouteBuilder`.
* Supports multiple shards via `IDictionary<string, IReplicator>`.
* Routes replication requests to `/replicate/{shard}/{action}`.
* Built-in request/response adapters for ASP.NET Core.

#### SelfHost Replicator

* `AddLuceneReplicationServer` extension for `IServiceCollection`.
* Runs `ReplicationServerService` as a hosted background service.
* Automatically configures and starts Kestrel on the given port.
* Supports multiple shard replicators out-of-the-box.

---

### 🛠 Usage Examples

**ASP.NET Core**

```csharp
var shardMap = new Dictionary<string, IReplicator>
{
    ["shard1"] = replicator1,
    ["shard2"] = replicator2
};

app.MapLuceneReplicationServer("/replicate", shardMap);
```

**SelfHost (Console/Worker Service)**

```csharp
builder.Services.AddLuceneReplicationServer(options =>
{
    options.Port = 5005;
    options.Replicators = new Dictionary<string, IReplicator>
    {
        ["shard1"] = replicator1,
        ["shard2"] = replicator2
    };
});
```

---

### 📂 File Structure

```
Lucene.Net.Extensions.AspNetCore.Replicator/
 ├── Adapters/
 │    ├── AspNetCoreReplicationRequest.cs
 │    └── AspNetCoreReplicationResponse.cs
 ├── LuceneReplicationEndpointExtensions.cs

Lucene.Net.Extensions.SelfHost.Replicator/
 ├── Options/
 │    └── ReplicationServerOptions.cs
 ├── Adapters/
 │    ├── AspNetCoreReplicationRequest.cs
 │    └── AspNetCoreReplicationResponse.cs
 ├── Services/
 │    └── ReplicationServerService.cs
 ├── ServiceCollectionExtensions.cs
```


---
